### PR TITLE
DECD 4750 - Exclusión de validación de campo token en el paymentResponse

### DIFF
--- a/app/code/community/Decidir/Decidir2/controllers/PaymentController.php
+++ b/app/code/community/Decidir/Decidir2/controllers/PaymentController.php
@@ -561,7 +561,7 @@ class Decidir_Decidir2_PaymentController extends Mage_Core_Controller_Front_Acti
         $response["status"] = $paymentResponse->getStatus();
         $response["id"] = $paymentResponse->getId();
         $response["site_transaction_id"] = $paymentResponse->getSiteTransactionId();
-        $response["token"] = $paymentResponse->getToken();
+        //$response["token"] = $paymentResponse->getToken();
         $response["payment_method_id"] = $paymentResponse->getPaymentMethodId();
         $response["bin"] = $paymentResponse->getBin();
         $response["amount"] = $paymentResponse->getAmount();


### PR DESCRIPTION
Incidente JIRA: DECD-4750
URL a la tarea en JIRA: http://jira.prismamp.com.ar:8080/browse/DECD-4750 

Descripción del cambio:
Se realizó el comentado de la linea del codigo que consideraba la validación del campo “token” en  de la respuesta. El mismo se encuentra en la clase “PaymentController.php” en el método “_getPaymentResponseData”

